### PR TITLE
Force old behavior of binutils/linker

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(mgclient-static
         ${OPENSSL_LIBRARIES} project_options project_c_warnings)
 if(MGCLIENT_ON_WINDOWS)
     target_link_libraries(mgclient-static PUBLIC ws2_32)
+    target_link_options(mgclient-static PUBLIC -Wl,--default-image-base-low)
 endif()
 
 add_library(mgclient-shared SHARED ${mgclient_src_files})
@@ -72,6 +73,7 @@ target_include_directories(mgclient-shared
 target_link_libraries(mgclient-shared PRIVATE ${OPENSSL_LIBRARIES})
 if(MGCLIENT_ON_WINDOWS)
     target_link_libraries(mgclient-shared PUBLIC ws2_32)
+    target_link_options(mgclient-shared PUBLIC -Wl,--default-image-base-low)
 endif()
 
 generate_export_header(mgclient-shared


### PR DESCRIPTION
Our issue is similar to this [1] issue. Though we shouldn't have
undefined weak symbols, but I think it is somehow connected. This should
be revisited when a new version of binutils comes out, as the issue
should be solved by the new version [2]. The solution is coming from
the official recommendtation [3].

[1] https://github.com/msys2/MINGW-packages/issues/7023
[2] https://github.com/msys2/MINGW-packages/pull/8259
[3] https://www.msys2.org/news/#2021-01-31-aslr-enabled-by-default