### PR TITLE
Remove usage of weak symbol on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,6 @@ target_link_libraries(mgclient-static
         ${OPENSSL_LIBRARIES} project_options project_c_warnings)
 if(MGCLIENT_ON_WINDOWS)
     target_link_libraries(mgclient-static PUBLIC ws2_32)
-    target_link_options(mgclient-static PUBLIC -Wl,--default-image-base-low)
 endif()
 
 add_library(mgclient-shared SHARED ${mgclient_src_files})
@@ -73,7 +72,6 @@ target_include_directories(mgclient-shared
 target_link_libraries(mgclient-shared PRIVATE ${OPENSSL_LIBRARIES})
 if(MGCLIENT_ON_WINDOWS)
     target_link_libraries(mgclient-shared PUBLIC ws2_32)
-    target_link_options(mgclient-shared PUBLIC -Wl,--default-image-base-low)
 endif()
 
 generate_export_header(mgclient-shared

--- a/src/mgcommon.h
+++ b/src/mgcommon.h
@@ -45,10 +45,10 @@
     if (DB_ACTIVE) fprintf(stderr, x); \
   } while (0)
 
-#ifdef MGCLIENT_ON_WINDOWS
-#define MG_ATTRIBUTE_WEAK
-#else
+#ifdef MGCLIENT_ON_APPLE
 #define MG_ATTRIBUTE_WEAK __attribute__((weak))
+#else
+#define MG_ATTRIBUTE_WEAK
 #endif
 
 #endif

--- a/src/mgcommon.h
+++ b/src/mgcommon.h
@@ -45,4 +45,10 @@
     if (DB_ACTIVE) fprintf(stderr, x); \
   } while (0)
 
+#ifdef MGCLIENT_ON_WINDOWS
+  #define MG_ATTRIBUTE_WEAK 
+#else
+  #define MG_ATTRIBUTE_WEAK __attribute__((weak))
+#endif
+
 #endif

--- a/src/mgcommon.h
+++ b/src/mgcommon.h
@@ -46,9 +46,9 @@
   } while (0)
 
 #ifdef MGCLIENT_ON_WINDOWS
-  #define MG_ATTRIBUTE_WEAK 
+#define MG_ATTRIBUTE_WEAK
 #else
-  #define MG_ATTRIBUTE_WEAK __attribute__((weak))
+#define MG_ATTRIBUTE_WEAK __attribute__((weak))
 #endif
 
 #endif

--- a/src/mgtransport.h
+++ b/src/mgtransport.h
@@ -22,6 +22,7 @@
 #include <openssl/ssl.h>
 
 #include "mgallocator.h"
+#include "mgcommon.h"
 
 typedef struct mg_transport {
   int (*send)(struct mg_transport *, const char *buf, size_t len);
@@ -66,7 +67,7 @@ void mg_raw_transport_destroy(struct mg_transport *);
 // This function is mocked in tests during linking by using --wrap. ON_APPLE
 // there is no --wrap. An alternative is to use -alias but if a symbol is
 // strong linking fails.
-__attribute__((weak)) int mg_secure_transport_init(
+MG_ATTRIBUTE_WEAK int mg_secure_transport_init(
     int sockfd, const char *cert_file, const char *key_file,
     mg_secure_transport **transport, mg_allocator *allocator);
 

--- a/src/mgtransport.h
+++ b/src/mgtransport.h
@@ -15,11 +15,10 @@
 #ifndef MGCLIENT_MGTRANSPORT_H
 #define MGCLIENT_MGTRANSPORT_H
 
-#include <stddef.h>
-
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#include <stddef.h>
 
 #include "mgallocator.h"
 #include "mgcommon.h"
@@ -67,9 +66,11 @@ void mg_raw_transport_destroy(struct mg_transport *);
 // This function is mocked in tests during linking by using --wrap. ON_APPLE
 // there is no --wrap. An alternative is to use -alias but if a symbol is
 // strong linking fails.
-MG_ATTRIBUTE_WEAK int mg_secure_transport_init(
-    int sockfd, const char *cert_file, const char *key_file,
-    mg_secure_transport **transport, mg_allocator *allocator);
+MG_ATTRIBUTE_WEAK int mg_secure_transport_init(int sockfd,
+                                               const char *cert_file,
+                                               const char *key_file,
+                                               mg_secure_transport **transport,
+                                               mg_allocator *allocator);
 
 int mg_secure_transport_send(mg_transport *, const char *buf, size_t len);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ add_gtest(client client.cpp)
 # We're mocking the mg_secure_transport_init function in the test.
 if(MGCLIENT_ON_APPLE)
     target_link_libraries(client -Wl,-alias,___wrap_mg_secure_transport_init,_mg_secure_transport_init)
-else()
+elseif(MGCLIENT_ON_LINUX)
     target_link_libraries(client -Wl,--wrap=mg_secure_transport_init)
 endif()
 


### PR DESCRIPTION
The weak attribute only necessary for testing purposes, but on Windows
these tests are not run, because of the missing implementation of
socketpair. Therefore there is no need to make the functions weak on
Windows.