### PR TITLE
fixed comparison typos and uninitialised error_buffer

### DIFF
--- a/mgclient_cpp/include/mgclient-value.hpp
+++ b/mgclient_cpp/include/mgclient-value.hpp
@@ -1837,7 +1837,7 @@ inline bool AreDateTimeZoneIdsEqual(
     const mg_date_time_zone_id *date_time_zone_id1,
     const mg_date_time_zone_id *date_time_zone_id2) {
   return mg_date_time_zone_id_seconds(date_time_zone_id1) ==
-             mg_date_time_zone_id_nanoseconds(date_time_zone_id2) &&
+             mg_date_time_zone_id_seconds(date_time_zone_id2) &&
          mg_date_time_zone_id_nanoseconds(date_time_zone_id1) ==
              mg_date_time_zone_id_nanoseconds(date_time_zone_id2) &&
          mg_date_time_zone_id_tz_id(date_time_zone_id1) ==
@@ -1847,7 +1847,7 @@ inline bool AreDateTimeZoneIdsEqual(
 inline bool AreLocalDateTimesEqual(const mg_local_date_time *local_date_time1,
                                    const mg_local_date_time *local_date_time2) {
   return mg_local_date_time_seconds(local_date_time1) ==
-             mg_local_date_time_nanoseconds(local_date_time2) &&
+             mg_local_date_time_seconds(local_date_time2) &&
          mg_local_date_time_nanoseconds(local_date_time1) ==
              mg_local_date_time_nanoseconds(local_date_time2);
 }

--- a/src/mgsession.c
+++ b/src/mgsession.c
@@ -83,6 +83,8 @@ mg_session *mg_session_init(mg_allocator *allocator) {
   session->explicit_transaction = 0;
   session->query_number = 0;
 
+  session->error_buffer[0] = 0;
+
   return session;
 
 cleanup:


### PR DESCRIPTION
The uninitialised error_buffer only comes into play when someone calls mg_session_error() on a mg_session with no previous errors.