### PR TITLE
Fix missing install of cpp headers

### DIFF
--- a/mgclient_cpp/CMakeLists.txt
+++ b/mgclient_cpp/CMakeLists.txt
@@ -3,5 +3,7 @@ target_include_directories(mgclient_cpp INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-
+install(DIRECTORY
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 target_link_libraries(mgclient_cpp INTERFACE mgclient-static)


### PR DESCRIPTION
I think we accidentally removed CPP header files from the install command here #28 because the place of the files was changed.