### PR TITLE
[master < T55] Add column names to cpp client

### DIFF
--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -195,7 +195,8 @@ inline bool Client::Execute(const std::string &statement) {
   const size_t list_length = mg_list_size(columns);
   columns_.clear();
   for (size_t i = 0; i < list_length; i++) {
-    columns_.push_back(std::string(Value(mg_list_at(columns, i)).ValueString()));
+    columns_.push_back(
+        std::string(Value(mg_list_at(columns, i)).ValueString()));
   }
 
   return true;
@@ -218,7 +219,8 @@ inline bool Client::Execute(const std::string &statement,
   const size_t list_length = mg_list_size(columns);
   columns_.clear();
   for (size_t i = 0; i < list_length; i++) {
-    columns_.push_back(std::string(Value(mg_list_at(columns, i)).ValueString()));
+    columns_.push_back(
+        std::string(Value(mg_list_at(columns, i)).ValueString()));
   }
 
   return true;

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -113,7 +113,7 @@ class Client {
   /// \brief Fetches all results.
   std::optional<std::vector<std::vector<Value>>> FetchAll();
 
-  std::vector<std::string> GetColumns();
+  const std::vector<std::string>& GetColumns() const;
 
   /// \brief Start a transaction.
   /// \return true when the transaction was successfully started, false
@@ -268,7 +268,7 @@ inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {
   return data;
 }
 
-inline std::vector<std::string> Client::GetColumns() { return columns_; }
+inline const std::vector<std::string>& Client::GetColumns() const { return columns_; }
 
 inline bool Client::BeginTransaction() {
   return mg_session_begin_transaction(session_, nullptr) == 0;

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -113,7 +113,7 @@ class Client {
   /// \brief Fetches all results.
   std::optional<std::vector<std::vector<Value>>> FetchAll();
 
-  const std::vector<std::string>& GetColumns() const;
+  const std::vector<std::string> &GetColumns() const;
 
   /// \brief Start a transaction.
   /// \return true when the transaction was successfully started, false
@@ -268,7 +268,9 @@ inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {
   return data;
 }
 
-inline const std::vector<std::string>& Client::GetColumns() const { return columns_; }
+inline const std::vector<std::string> &Client::GetColumns() const {
+  return columns_;
+}
 
 inline bool Client::BeginTransaction() {
   return mg_session_begin_transaction(session_, nullptr) == 0;


### PR DESCRIPTION
The feature enables people to run mgclient and fetch columns of the executed query to make sure the name of the column represents the result. `GetColumns` method returns a vector of columns, which correspond to the vector of values in a row, and can be mapped with the index.