### PR TITLE
Add support for auth with custom schemes

### DIFF
--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -1233,10 +1233,14 @@ MGCLIENT_EXPORT void mg_session_params_set_host(mg_session_params *,
                                                 const char *host);
 MGCLIENT_EXPORT void mg_session_params_set_port(mg_session_params *,
                                                 uint16_t port);
+MGCLIENT_EXPORT void mg_session_params_set_scheme(mg_session_params *,
+                                                  const char *scheme);
 MGCLIENT_EXPORT void mg_session_params_set_username(mg_session_params *,
                                                     const char *username);
 MGCLIENT_EXPORT void mg_session_params_set_password(mg_session_params *,
                                                     const char *password);
+MGCLIENT_EXPORT void mg_session_params_set_credentials(mg_session_params *,
+                                                       const char *credentials);
 MGCLIENT_EXPORT void mg_session_params_set_user_agent(mg_session_params *,
                                                       const char *user_agent);
 MGCLIENT_EXPORT void mg_session_params_set_sslmode(mg_session_params *,

--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -1239,8 +1239,6 @@ MGCLIENT_EXPORT void mg_session_params_set_username(mg_session_params *,
                                                     const char *username);
 MGCLIENT_EXPORT void mg_session_params_set_password(mg_session_params *,
                                                     const char *password);
-MGCLIENT_EXPORT void mg_session_params_set_credentials(mg_session_params *,
-                                                       const char *credentials);
 MGCLIENT_EXPORT void mg_session_params_set_user_agent(mg_session_params *,
                                                       const char *user_agent);
 MGCLIENT_EXPORT void mg_session_params_set_sslmode(mg_session_params *,

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -57,7 +57,7 @@ class Client {
   struct Params {
     std::string host = "127.0.0.1";
     uint16_t port = 7687;
-    std::string scheme = "basic";
+    std::string scheme = "none";
     std::string username = "";
     std::string password = "";
     bool use_ssl = false;
@@ -149,16 +149,24 @@ inline std::unique_ptr<Client> Client::Connect(const Client::Params &params) {
   if (!mg_params) {
     return nullptr;
   }
-  mg_session_params_set_host(mg_params, params.host.c_str());
-  mg_session_params_set_port(mg_params, params.port);
-  mg_session_params_set_scheme(mg_params, params.scheme.c_str());
+  if (!params.host.empty()) {
+    mg_session_params_set_host(mg_params, params.host.c_str());
+  }
+  if (params.port != 0) {
+    mg_session_params_set_port(mg_params, params.port);
+  }
+  if (!params.scheme.empty()) {
+    mg_session_params_set_scheme(mg_params, params.scheme.c_str());
+  }
   if (!params.username.empty()) {
     mg_session_params_set_username(mg_params, params.username.c_str());
   }
   if (!params.password.empty()) {
     mg_session_params_set_password(mg_params, params.password.c_str());
   }
-  mg_session_params_set_user_agent(mg_params, params.user_agent.c_str());
+  if (!params.user_agent.empty()) {
+    mg_session_params_set_user_agent(mg_params, params.user_agent.c_str());
+  }
   mg_session_params_set_sslmode(
       mg_params, params.use_ssl ? MG_SSLMODE_REQUIRE : MG_SSLMODE_DISABLE);
 

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -260,7 +260,8 @@ inline std::optional<std::vector<Value>> Client::FetchOne() {
 }
 
 inline void Client::DiscardAll() { 
-  while (FetchOne()); 
+  while (FetchOne())
+    ;
 }
 
 inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -57,8 +57,10 @@ class Client {
   struct Params {
     std::string host = "127.0.0.1";
     uint16_t port = 7687;
+    std::string scheme = "basic";
     std::string username = "";
     std::string password = "";
+    std::string credentials = "";
     bool use_ssl = false;
     std::string user_agent = "mgclient++/" + std::string(mg_client_version());
   };
@@ -150,9 +152,13 @@ inline std::unique_ptr<Client> Client::Connect(const Client::Params &params) {
   }
   mg_session_params_set_host(mg_params, params.host.c_str());
   mg_session_params_set_port(mg_params, params.port);
+  mg_session_params_set_scheme(mg_params, params.scheme.c_str());
   if (!params.username.empty()) {
     mg_session_params_set_username(mg_params, params.username.c_str());
     mg_session_params_set_password(mg_params, params.password.c_str());
+  }
+  if (!params.credentials.empty()) {
+    mg_session_params_set_credentials(mg_params, params.credentials.c_str());
   }
   mg_session_params_set_user_agent(mg_params, params.user_agent.c_str());
   mg_session_params_set_sslmode(
@@ -255,10 +261,7 @@ inline std::optional<std::vector<Value>> Client::FetchOne() {
   return values;
 }
 
-inline void Client::DiscardAll() {
-  while (FetchOne())
-    ;
-}
+inline void Client::DiscardAll() { while (FetchOne()); }
 
 inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {
   std::vector<std::vector<Value>> data;

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -60,7 +60,6 @@ class Client {
     std::string scheme = "basic";
     std::string username = "";
     std::string password = "";
-    std::string credentials = "";
     bool use_ssl = false;
     std::string user_agent = "mgclient++/" + std::string(mg_client_version());
   };
@@ -155,10 +154,9 @@ inline std::unique_ptr<Client> Client::Connect(const Client::Params &params) {
   mg_session_params_set_scheme(mg_params, params.scheme.c_str());
   if (!params.username.empty()) {
     mg_session_params_set_username(mg_params, params.username.c_str());
-    mg_session_params_set_password(mg_params, params.password.c_str());
   }
-  if (!params.credentials.empty()) {
-    mg_session_params_set_credentials(mg_params, params.credentials.c_str());
+  if (!params.password.empty()) {
+    mg_session_params_set_password(mg_params, params.password.c_str());
   }
   mg_session_params_set_user_agent(mg_params, params.user_agent.c_str());
   mg_session_params_set_sslmode(

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -259,7 +259,7 @@ inline std::optional<std::vector<Value>> Client::FetchOne() {
   return values;
 }
 
-inline void Client::DiscardAll() { 
+inline void Client::DiscardAll() {
   while (FetchOne())
     ;
 }

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -259,7 +259,9 @@ inline std::optional<std::vector<Value>> Client::FetchOne() {
   return values;
 }
 
-inline void Client::DiscardAll() { while (FetchOne()); }
+inline void Client::DiscardAll() { 
+  while (FetchOne()); 
+}
 
 inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {
   std::vector<std::vector<Value>> data;

--- a/src/mgclient.c
+++ b/src/mgclient.c
@@ -390,7 +390,7 @@ static mg_map *build_hello_extra(const char *user_agent, const char *scheme,
   // not have such requirements:
   // https://neo4j.com/docs/bolt/current/bolt/message/#messages-hello
   // https://neo4j.com/docs/bolt/current/bolt/message/#messages-logon
-  if (scheme && strcmp(scheme, "basic")) {
+  if (scheme && strcmp(scheme, "basic") == 0) {
     assert(username && password);
   }
 

--- a/src/mgclient.c
+++ b/src/mgclient.c
@@ -390,6 +390,7 @@ static mg_map *build_hello_extra(const char *user_agent, const char *scheme,
   // by Memgraph) do not have such requirements:
   // https://neo4j.com/docs/bolt/current/bolt/message/#messages-hello
   // https://neo4j.com/docs/bolt/current/bolt/message/#messages-logon
+  // NOTE: HELLO message does NOT contain schema after Bolt 5.0.
   if (scheme && strcmp(scheme, "basic") == 0) {
     assert(username && password);
   }
@@ -402,7 +403,7 @@ static mg_map *build_hello_extra(const char *user_agent, const char *scheme,
     return extra;
   }
 
-  mg_value *scheme_ = mg_value_make_string(scheme ? scheme : "basic");
+  mg_value *scheme_ = mg_value_make_string(scheme ? scheme : "none"); // NOTE: Makes none default.
   if (!scheme_ || mg_map_insert_unsafe(extra, "scheme", scheme_) != 0) {
     goto cleanup;
   }

--- a/src/mgclient.c
+++ b/src/mgclient.c
@@ -385,9 +385,9 @@ static mg_map *build_hello_extra(const char *user_agent, const char *scheme,
     }
   }
 
-  // The "basic" scheme requires a username and a password in the HELLO message.
-  // Other schemes (save for "kerberos", which is not supported by Memgraph) do
-  // not have such requirements:
+  // The "basic" scheme requires a username and a password/credential within the
+  // HELLO message. Other schemes (save for "kerberos", which is not supported
+  // by Memgraph) do not have such requirements:
   // https://neo4j.com/docs/bolt/current/bolt/message/#messages-hello
   // https://neo4j.com/docs/bolt/current/bolt/message/#messages-logon
   if (scheme && strcmp(scheme, "basic") == 0) {

--- a/src/mgclient.c
+++ b/src/mgclient.c
@@ -88,6 +88,7 @@ mg_session_params *mg_session_params_make(void) {
   params->address = NULL;
   params->host = NULL;
   params->port = 0;
+  params->scheme = NULL;
   params->username = NULL;
   params->password = NULL;
   params->user_agent = MG_USER_AGENT;

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -19,7 +19,6 @@
 #include <thread>
 
 #include "mgclient.h"
-#include "mgcommon.h"
 #include "mgsession.h"
 #include "mgsocket.h"
 

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -507,6 +507,69 @@ TEST_F(ConnectTest, Success) {
   ASSERT_MEMORY_OK();
 }
 
+// Bolt v1 server that completes the handshake by selecting version 1,
+// reads the client's INIT message verifying basic-auth credentials, and
+// replies with SUCCESS.
+auto make_v1_server_success_basic = [](int sockfd) {
+  {
+    char handshake[20];
+    ASSERT_EQ(RecvData(sockfd, handshake, 20), 0);
+    ASSERT_EQ(std::string(handshake, 4), "\x60\x60\xB0\x17"s);
+    ASSERT_EQ(std::string(handshake + 4, 4), "\x00\x00\x01\x04"s);
+    ASSERT_EQ(std::string(handshake + 8, 4), "\x00\x00\x00\x01"s);
+    ASSERT_EQ(std::string(handshake + 12, 4), "\x00\x00\x00\x00"s);
+    ASSERT_EQ(std::string(handshake + 16, 4), "\x00\x00\x00\x00"s);
+
+    uint32_t version = htobe32(1);
+    ASSERT_EQ(SendData(sockfd, (char *)&version, 4), 0);
+  }
+
+  mg_session *session = mg_session_init(&mg_system_allocator);
+  ASSERT_TRUE(session);
+  session->version = 1;
+  mg_raw_transport_init(sockfd, (mg_raw_transport **)&session->transport,
+                        &mg_system_allocator);
+
+  {
+    mg_message *message;
+    ASSERT_EQ(mg_session_receive_message(session), 0);
+    ASSERT_EQ(mg_session_read_bolt_message(session, &message), 0);
+    ASSERT_EQ(message->type, MG_MESSAGE_TYPE_INIT);
+
+    mg_message_init *msg_init = message->init_v;
+    EXPECT_EQ(
+        std::string(msg_init->client_name->data, msg_init->client_name->size),
+        MG_USER_AGENT);
+    ASSERT_EQ(mg_map_size(msg_init->auth_token), 3u);
+
+    const mg_value *scheme_val = mg_map_at(msg_init->auth_token, "scheme");
+    ASSERT_TRUE(scheme_val);
+    ASSERT_EQ(mg_value_get_type(scheme_val), MG_VALUE_TYPE_STRING);
+    const mg_string *scheme = mg_value_string(scheme_val);
+    ASSERT_EQ(std::string(scheme->data, scheme->size), "basic");
+
+    const mg_value *principal_val =
+        mg_map_at(msg_init->auth_token, "principal");
+    ASSERT_TRUE(principal_val);
+    ASSERT_EQ(mg_value_get_type(principal_val), MG_VALUE_TYPE_STRING);
+    const mg_string *principal = mg_value_string(principal_val);
+    ASSERT_EQ(std::string(principal->data, principal->size), "user");
+
+    const mg_value *credentials_val =
+        mg_map_at(msg_init->auth_token, "credentials");
+    ASSERT_TRUE(credentials_val);
+    ASSERT_EQ(mg_value_get_type(credentials_val), MG_VALUE_TYPE_STRING);
+    const mg_string *credentials = mg_value_string(credentials_val);
+    ASSERT_EQ(std::string(credentials->data, credentials->size), "pass");
+
+    mg_message_destroy_ca(message, session->decoder_allocator);
+  }
+
+  ASSERT_EQ(mg_session_send_success_message(session, &mg_empty_map), 0);
+
+  mg_session_destroy(session);
+};
+
 // Bolt v4 server that completes the handshake by selecting version 4.1,
 // reads the client's HELLO message, verifies the auth fields against the
 // supplied expectations, and replies with SUCCESS. When expected_principal /
@@ -604,6 +667,33 @@ TEST_F(ConnectTest, Success_v4) {
 }
 
 TEST_F(ConnectTest, SuccessWithSSL) {
+  RunServer(make_v1_server_success_basic);
+
+  mg_secure_transport_init_called = 0;
+  trust_callback_ok = 0;
+
+  mg_session_params *params = mg_session_params_make();
+  mg_session_params_set_host(params, "localhost");
+  mg_session_params_set_port(params, port);
+  mg_session_params_set_username(params, "user");
+  mg_session_params_set_password(params, "pass");
+  mg_session_params_set_sslmode(params, MG_SSLMODE_REQUIRE);
+  mg_session_params_set_sslcert(params, "/path/to/cert");
+  mg_session_params_set_sslkey(params, "/path/to/key");
+  mg_session_params_set_trust_callback(params, trust_callback);
+  int trust_data = 42;
+  mg_session_params_set_trust_data(params, (void *)&trust_data);
+  mg_session *session;
+  ASSERT_EQ(mg_connect_ca(params, &session, (mg_allocator *)&allocator), 0);
+  ASSERT_EQ(mg_secure_transport_init_called, 1);
+  ASSERT_EQ(trust_callback_ok, 1);
+  EXPECT_EQ(mg_session_status(session), MG_SESSION_READY);
+  mg_session_params_destroy(params);
+  mg_session_destroy(session);
+  ASSERT_MEMORY_OK();
+}
+
+TEST_F(ConnectTest, SuccessWithSSL_v4) {
   RunServer(make_v4_server_success("basic", "user", "pass"));
 
   mg_secure_transport_init_called = 0;

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -507,76 +507,92 @@ TEST_F(ConnectTest, Success) {
   ASSERT_MEMORY_OK();
 }
 
-auto run_v4_server_success = [](int sockfd) {
-  // Perform handshake.
-  {
-    char handshake[20];
-    ASSERT_EQ(RecvData(sockfd, handshake, 20), 0);
-    ASSERT_EQ(std::string(handshake, 4), "\x60\x60\xB0\x17"s);
-    ASSERT_EQ(std::string(handshake + 4, 4), "\x00\x00\x01\x04"s);
-    ASSERT_EQ(std::string(handshake + 8, 4), "\x00\x00\x00\x01"s);
-    ASSERT_EQ(std::string(handshake + 12, 4), "\x00\x00\x00\x00"s);
-    ASSERT_EQ(std::string(handshake + 16, 4), "\x00\x00\x00\x00"s);
-
-    uint32_t version = htobe32(1);
-    ASSERT_EQ(SendData(sockfd, (char *)&version, 4), 0);
-  }
-
-  mg_session *session = mg_session_init(&mg_system_allocator);
-  ASSERT_TRUE(session);
-  session->version = 1;
-  mg_raw_transport_init(sockfd, (mg_raw_transport **)&session->transport,
-                        &mg_system_allocator);
-
-  // Read INIT message.
-  {
-    mg_message *message;
-    ASSERT_EQ(mg_session_receive_message(session), 0);
-    ASSERT_EQ(mg_session_read_bolt_message(session, &message), 0);
-    ASSERT_EQ(message->type, MG_MESSAGE_TYPE_INIT);
-
-    mg_message_init *msg_init = message->init_v;
-    EXPECT_EQ(
-        std::string(msg_init->client_name->data, msg_init->client_name->size),
-        MG_USER_AGENT);
+// Bolt v4 server that completes the handshake by selecting version 4.1,
+// reads the client's HELLO message, verifies the auth fields against the
+// supplied expectations, and replies with SUCCESS. When expected_principal /
+// expected_credentials are empty, the server expects an extra map of just
+// {user_agent, scheme}; otherwise it expects all four fields.
+auto make_v4_server_success(std::string expected_scheme,
+                            std::string expected_principal = "",
+                            std::string expected_credentials = "") {
+  return [expected_scheme = std::move(expected_scheme),
+          expected_principal = std::move(expected_principal),
+          expected_credentials = std::move(expected_credentials)](int sockfd) {
     {
-      ASSERT_EQ(mg_map_size(msg_init->auth_token), 3u);
+      char handshake[20];
+      ASSERT_EQ(RecvData(sockfd, handshake, 20), 0);
+      ASSERT_EQ(std::string(handshake, 4), "\x60\x60\xB0\x17"s);
+      ASSERT_EQ(std::string(handshake + 4, 4), "\x00\x00\x01\x04"s);
+      ASSERT_EQ(std::string(handshake + 8, 4), "\x00\x00\x00\x01"s);
+      ASSERT_EQ(std::string(handshake + 12, 4), "\x00\x00\x00\x00"s);
+      ASSERT_EQ(std::string(handshake + 16, 4), "\x00\x00\x00\x00"s);
 
-      const mg_value *scheme_val = mg_map_at(msg_init->auth_token, "scheme");
+      uint32_t version = htobe32(0x0104);
+      ASSERT_EQ(SendData(sockfd, (char *)&version, 4), 0);
+    }
+
+    mg_session *session = mg_session_init(&mg_system_allocator);
+    ASSERT_TRUE(session);
+    session->version = 4;
+    mg_raw_transport_init(sockfd, (mg_raw_transport **)&session->transport,
+                          &mg_system_allocator);
+
+    {
+      mg_message *message;
+      ASSERT_EQ(mg_session_receive_message(session), 0);
+      ASSERT_EQ(mg_session_read_bolt_message(session, &message), 0);
+      ASSERT_EQ(message->type, MG_MESSAGE_TYPE_HELLO);
+
+      mg_message_hello *msg_hello = message->hello_v;
+      const bool with_creds = !expected_principal.empty();
+      ASSERT_EQ(mg_map_size(msg_hello->extra), with_creds ? 4u : 2u);
+
+      const mg_value *user_agent_val =
+          mg_map_at(msg_hello->extra, "user_agent");
+      ASSERT_TRUE(user_agent_val);
+      ASSERT_EQ(mg_value_get_type(user_agent_val), MG_VALUE_TYPE_STRING);
+      const mg_string *user_agent = mg_value_string(user_agent_val);
+      ASSERT_EQ(std::string(user_agent->data, user_agent->size), MG_USER_AGENT);
+
+      const mg_value *scheme_val = mg_map_at(msg_hello->extra, "scheme");
       ASSERT_TRUE(scheme_val);
       ASSERT_EQ(mg_value_get_type(scheme_val), MG_VALUE_TYPE_STRING);
       const mg_string *scheme = mg_value_string(scheme_val);
-      ASSERT_EQ(std::string(scheme->data, scheme->size), "basic");
+      ASSERT_EQ(std::string(scheme->data, scheme->size), expected_scheme);
 
-      const mg_value *principal_val =
-          mg_map_at(msg_init->auth_token, "principal");
-      ASSERT_TRUE(principal_val);
-      ASSERT_EQ(mg_value_get_type(principal_val), MG_VALUE_TYPE_STRING);
-      const mg_string *principal = mg_value_string(principal_val);
-      ASSERT_EQ(std::string(principal->data, principal->size), "user");
+      if (with_creds) {
+        const mg_value *principal_val =
+            mg_map_at(msg_hello->extra, "principal");
+        ASSERT_TRUE(principal_val);
+        ASSERT_EQ(mg_value_get_type(principal_val), MG_VALUE_TYPE_STRING);
+        const mg_string *principal = mg_value_string(principal_val);
+        ASSERT_EQ(std::string(principal->data, principal->size),
+                  expected_principal);
 
-      const mg_value *credentials_val =
-          mg_map_at(msg_init->auth_token, "credentials");
-      ASSERT_TRUE(credentials_val);
-      ASSERT_EQ(mg_value_get_type(credentials_val), MG_VALUE_TYPE_STRING);
-      const mg_string *credentials = mg_value_string(credentials_val);
-      ASSERT_EQ(std::string(credentials->data, credentials->size), "pass");
+        const mg_value *credentials_val =
+            mg_map_at(msg_hello->extra, "credentials");
+        ASSERT_TRUE(credentials_val);
+        ASSERT_EQ(mg_value_get_type(credentials_val), MG_VALUE_TYPE_STRING);
+        const mg_string *credentials = mg_value_string(credentials_val);
+        ASSERT_EQ(std::string(credentials->data, credentials->size),
+                  expected_credentials);
+      }
+
+      mg_message_destroy_ca(message, session->decoder_allocator);
     }
 
-    mg_message_destroy_ca(message, session->decoder_allocator);
-  }
+    ASSERT_EQ(mg_session_send_success_message(session, &mg_empty_map), 0);
 
-  // Send SUCCESS message.
-  ASSERT_EQ(mg_session_send_success_message(session, &mg_empty_map), 0);
-
-  mg_session_destroy(session);
-};
+    mg_session_destroy(session);
+  };
+}
 
 TEST_F(ConnectTest, Success_v4) {
-  RunServer(run_v4_server_success);
+  RunServer(make_v4_server_success("basic", "user", "pass"));
   mg_session_params *params = mg_session_params_make();
   mg_session_params_set_host(params, "127.0.0.1");
   mg_session_params_set_port(params, port);
+  mg_session_params_set_scheme(params, "basic");
   mg_session_params_set_username(params, "user");
   mg_session_params_set_password(params, "pass");
   mg_session *session;
@@ -588,7 +604,7 @@ TEST_F(ConnectTest, Success_v4) {
 }
 
 TEST_F(ConnectTest, SuccessWithSSL) {
-  RunServer(run_v4_server_success);
+  RunServer(make_v4_server_success("basic", "user", "pass"));
 
   mg_secure_transport_init_called = 0;
   trust_callback_ok = 0;
@@ -596,6 +612,7 @@ TEST_F(ConnectTest, SuccessWithSSL) {
   mg_session_params *params = mg_session_params_make();
   mg_session_params_set_host(params, "localhost");
   mg_session_params_set_port(params, port);
+  mg_session_params_set_scheme(params, "basic");
   mg_session_params_set_username(params, "user");
   mg_session_params_set_password(params, "pass");
   mg_session_params_set_sslmode(params, MG_SSLMODE_REQUIRE);
@@ -615,13 +632,26 @@ TEST_F(ConnectTest, SuccessWithSSL) {
 }
 
 TEST_F(ConnectTest, CustomScheme) {
-  RunServer(run_v4_server_success);
+  RunServer(make_v4_server_success("custom_scheme", "user", "pass"));
   mg_session_params *params = mg_session_params_make();
   mg_session_params_set_host(params, "127.0.0.1");
   mg_session_params_set_port(params, port);
   mg_session_params_set_scheme(params, "custom_scheme");
   mg_session_params_set_username(params, "user");
   mg_session_params_set_password(params, "pass");
+  mg_session *session;
+  ASSERT_EQ(mg_connect_ca(params, &session, (mg_allocator *)&allocator), 0);
+  EXPECT_EQ(mg_session_status(session), MG_SESSION_READY);
+  mg_session_params_destroy(params);
+  mg_session_destroy(session);
+  ASSERT_MEMORY_OK();
+}
+
+TEST_F(ConnectTest, SuccessNoAuth_v4) {
+  RunServer(make_v4_server_success("none"));
+  mg_session_params *params = mg_session_params_make();
+  mg_session_params_set_host(params, "127.0.0.1");
+  mg_session_params_set_port(params, port);
   mg_session *session;
   ASSERT_EQ(mg_connect_ca(params, &session, (mg_allocator *)&allocator), 0);
   EXPECT_EQ(mg_session_status(session), MG_SESSION_READY);

--- a/tests/integration/basic_cpp.cpp
+++ b/tests/integration/basic_cpp.cpp
@@ -35,7 +35,7 @@ class MemgraphConnection : public ::testing::Test {
 
     client = mg::Client::Connect(
         {GetEnvOrDefault<std::string>("MEMGRAPH_HOST", "127.0.0.1"),
-         GetEnvOrDefault<uint16_t>("MEMGRAPH_PORT", 7687), "", "",
+         GetEnvOrDefault<uint16_t>("MEMGRAPH_PORT", 7687), "basic", "", "",
          GetEnvOrDefault<bool>("MEMGRAPH_SSLMODE", false), ""});
 
     ASSERT_TRUE(client);


### PR DESCRIPTION
This PR extends the processing of Bolt v4 HELLO message to support custom auth schemes. The purpose is twofold:
* improve Bolt support
* support SSO via clients other than Lab (Memgraph’s SSO requires custom values of the `scheme` field)

### TODOs
- [ ] Make sure Bolt v4 is fully correct