### PR TITLE
Fix clang formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   clang_check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set-up repository
       uses: actions/checkout@v4

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -255,10 +255,7 @@ inline std::optional<std::vector<Value>> Client::FetchOne() {
   return values;
 }
 
-inline void Client::DiscardAll() {
-  while (FetchOne())
-    ;
-}
+inline void Client::DiscardAll() { while (FetchOne()); }
 
 inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {
   std::vector<std::vector<Value>> data;

--- a/tool/format.sh
+++ b/tool/format.sh
@@ -7,7 +7,7 @@ cd "$DIR/.."
 
 ALL_FILES_TO_CHECK=$(find . -type f -regex ".*\.\(cpp\|hpp\|c\|h\)$" -print | paste -sd " ")
 for file in ${ALL_FILES_TO_CHECK}; do
-  clang-format -i -verbose "${file}"
+  clang-format --style=file -i -verbose "${file}"
 done
 changes="$(git diff)"
 if [[ ! -z "${changes}" ]]; then


### PR DESCRIPTION
- Use `.clang-format` file from root of repo to define style in `format.sh`
- Use latest Ubuntu runner
- Fix formatting error found in `mgclient.hpp`