### PR TITLE
Updates to CMakeLists to fix Windows pymgclient builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,8 @@ else()
             ${OPENSSL_LIBRARIES} project_options project_c_warnings)
 
     if(MGCLIENT_ON_WINDOWS)
-        target_link_libraries(mgclient-static PUBLIC ws2_32)
+        target_link_libraries(mgclient-static PUBLIC ws2_32 crypt32 gdi32)
+        target_link_libraries(mgclient-shared PUBLIC ws2_32 crypt32 gdi32)
     endif()
 
     add_library(mgclient-shared SHARED ${mgclient_src_files})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,6 @@ else()
 
     if(MGCLIENT_ON_WINDOWS)
         target_link_libraries(mgclient-static PUBLIC ws2_32 crypt32 gdi32)
-        target_link_libraries(mgclient-shared PUBLIC ws2_32 crypt32 gdi32)
     endif()
 
     add_library(mgclient-shared SHARED ${mgclient_src_files})
@@ -97,7 +96,7 @@ else()
             ${OPENSSL_LIBRARIES} project_options project_c_warnings)
 
     if(MGCLIENT_ON_WINDOWS)
-        target_link_libraries(mgclient-shared PUBLIC ws2_32)
+        target_link_libraries(mgclient-shared PUBLIC ws2_32 crypt32 gdi32)
     endif()
 
     generate_export_header(mgclient-shared


### PR DESCRIPTION
Added `crypt32` and `gdi32` to CMakeLists to enable newer Windows builds to pass in `pymgclient`: [#67](https://github.com/memgraph/pymgclient/pull/67)