### PR TITLE
Treat Bolt `DateTime::Structure` offset as seconds, rather than minutes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(WASM)
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/wasm/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake")
 endif()
 
-project(mgclient VERSION 1.4.5)
+project(mgclient VERSION 1.4.6)
 # Minor version increase can also mean ABI incompatibility with previous
 # versions. IMPORTANT: Take care of the SO version manually.
 set(mgclient_SOVERSION 2)

--- a/src/mgsession-decoder.c
+++ b/src/mgsession-decoder.c
@@ -675,10 +675,12 @@ int mg_session_read_date_time(mg_session *session, mg_date_time **date_time) {
     goto cleanup;
   }
 
-  status = mg_session_read_integer(session, &date_time_tmp->tz_offset_minutes);
+  int64_t tz_offset_seconds;
+  status = mg_session_read_integer(session, &tz_offset_seconds);
   if (status != 0) {
     goto cleanup;
   }
+  date_time_tmp->tz_offset_minutes = tz_offset_seconds / 60;
 
   *date_time = date_time_tmp;
   return 0;

--- a/tests/bolt-testdata.hpp
+++ b/tests/bolt-testdata.hpp
@@ -430,7 +430,7 @@ std::vector<ValueTestParam> DateTimeTestCases() {
     encoded_date_time += "\xB3\x46"s;
     encoded_date_time += "\x01"s;
     encoded_date_time += "\x01"s;
-    encoded_date_time += "\x01"s;
+    encoded_date_time += "\x3C"s;
 
     inputs.push_back({mg_value_make_date_time(date_time), encoded_date_time});
   }


### PR DESCRIPTION
`DateTime::Structure` transmits the `offset` as seconds, but our code treated this as minutes. This PR truncates the seconds to minutes, and hence fixes `ZonedDateTime` support.

The actual `DateTime::Structure` is documented here: https://neo4j.com/docs/bolt/current/bolt/structure-semantics/#structure-datetime

```
DateTime::Structure(
    seconds::Integer,
    nanoseconds::Integer,
    tz_offset_seconds::Integer,
)
```

(Also bumps the semver to 1.4.6)