### PR TITLE
Transport ZonedDateTimes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(WASM)
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/wasm/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake")
 endif()
 
-project(mgclient VERSION 1.4.6)
+project(mgclient VERSION 1.5.0)
 # Minor version increase can also mean ABI incompatibility with previous
 # versions. IMPORTANT: Take care of the SO version manually.
 set(mgclient_SOVERSION 2)

--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -962,8 +962,14 @@ MGCLIENT_EXPORT void mg_date_time_zone_id_destroy(
 
 /// Creates mg_date_time from seconds, nanoseconds and timezone offset.
 /// \return a pointer to mg_date_time or NULL if an error occurred.
-MGCLIENT_EXPORT mg_date_time *mg_date_time_make(
-    int64_t seconds, int64_t nanoseconds, int32_t tz_offset_minutes);
+MGCLIENT_EXPORT mg_date_time *mg_date_time_make(int64_t seconds,
+                                                int64_t nanoseconds,
+                                                int32_t tz_offset_minutes);
+
+/// Creates mg_date_time_zone_id from seconds, nanoseconds, and timezone name.
+/// \return a pointer to mg_date_time_zone_id or NULL if an error occurred.
+MGCLIENT_EXPORT mg_date_time_zone_id *mg_date_time_zone_id_make(
+    int64_t seconds, int64_t nanoseconds, const char *timezone_name);
 
 /// Creates mg_local_date_time from seconds and nanoseconds.
 /// \return a pointer to mg_local_date_time or NULL if an error occurred.

--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -960,6 +960,12 @@ MGCLIENT_EXPORT mg_date_time_zone_id *mg_date_time_zone_id_copy(
 MGCLIENT_EXPORT void mg_date_time_zone_id_destroy(
     mg_date_time_zone_id *date_time_zone_id);
 
+/// Creates mg_date_time from seconds, nanoseconds and timezone offset.
+/// \return a pointer to mg_date_time or NULL if an error occurred.
+MGCLIENT_EXPORT mg_date_time *mg_zoned_date_time_make(int64_t seconds,
+                                                     int64_t nanoseconds,
+                                                     int32_t tz_offset_minutes);
+
 /// Creates mg_local_date_time from seconds and nanoseconds.
 /// \return a pointer to mg_local_date_time or NULL if an error occurred.
 MGCLIENT_EXPORT mg_local_date_time *mg_local_date_time_make(

--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -947,8 +947,8 @@ MGCLIENT_EXPORT int64_t
 mg_date_time_zone_id_nanoseconds(const mg_date_time_zone_id *date_time_zone_id);
 
 /// Returns time zone name.
-MGCLIENT_EXPORT const mg_string *
-mg_date_time_zone_id_timezone_name(const mg_date_time_zone_id *date_time_zone_id);
+MGCLIENT_EXPORT const mg_string *mg_date_time_zone_id_timezone_name(
+    const mg_date_time_zone_id *date_time_zone_id);
 
 /// Creates a copy of the given date and time.
 ///

--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -962,9 +962,8 @@ MGCLIENT_EXPORT void mg_date_time_zone_id_destroy(
 
 /// Creates mg_date_time from seconds, nanoseconds and timezone offset.
 /// \return a pointer to mg_date_time or NULL if an error occurred.
-MGCLIENT_EXPORT mg_date_time *mg_zoned_date_time_make(int64_t seconds,
-                                                     int64_t nanoseconds,
-                                                     int32_t tz_offset_minutes);
+MGCLIENT_EXPORT mg_date_time *mg_zoned_date_time_make(
+    int64_t seconds, int64_t nanoseconds, int32_t tz_offset_minutes);
 
 /// Creates mg_local_date_time from seconds and nanoseconds.
 /// \return a pointer to mg_local_date_time or NULL if an error occurred.

--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -946,9 +946,9 @@ mg_date_time_zone_id_seconds(const mg_date_time_zone_id *date_time_zone_id);
 MGCLIENT_EXPORT int64_t
 mg_date_time_zone_id_nanoseconds(const mg_date_time_zone_id *date_time_zone_id);
 
-/// Returns time zone represented by the identifier.
-MGCLIENT_EXPORT int64_t
-mg_date_time_zone_id_tz_id(const mg_date_time_zone_id *date_time_zone_id);
+/// Returns time zone name.
+MGCLIENT_EXPORT const mg_string *
+mg_date_time_zone_id_timezone_name(const mg_date_time_zone_id *date_time_zone_id);
 
 /// Creates a copy of the given date and time.
 ///

--- a/include/mgclient.h
+++ b/include/mgclient.h
@@ -962,7 +962,7 @@ MGCLIENT_EXPORT void mg_date_time_zone_id_destroy(
 
 /// Creates mg_date_time from seconds, nanoseconds and timezone offset.
 /// \return a pointer to mg_date_time or NULL if an error occurred.
-MGCLIENT_EXPORT mg_date_time *mg_zoned_date_time_make(
+MGCLIENT_EXPORT mg_date_time *mg_date_time_make(
     int64_t seconds, int64_t nanoseconds, int32_t tz_offset_minutes);
 
 /// Creates mg_local_date_time from seconds and nanoseconds.

--- a/mgclient_cpp/include/mgclient-value.hpp
+++ b/mgclient_cpp/include/mgclient-value.hpp
@@ -44,14 +44,6 @@ TDest MemcpyCast(TSrc src) {
   return dest;
 }
 
-inline bool AreStringsEqual(const mg_string *s1, const mg_string *s2) {
-  if (s1 == s2) return true;
-  if (!s1 || !s2) return false;
-  return mg_string_size(s1) == mg_string_size(s2) &&
-         memcmp(mg_string_data(s1), mg_string_data(s2), mg_string_size(s1)) ==
-             0;
-}
-
 }  // namespace detail
 
 // Forward declarations:
@@ -1695,6 +1687,14 @@ inline Value::Type ConvertType(mg_value_type type) {
 }
 
 inline bool AreValuesEqual(const mg_value *value1, const mg_value *value2);
+
+inline bool AreStringsEqual(const mg_string *s1, const mg_string *s2) {
+  if (s1 == s2) return true;
+  if (!s1 || !s2) return false;
+  return mg_string_size(s1) == mg_string_size(s2) &&
+         memcmp(mg_string_data(s1), mg_string_data(s2), mg_string_size(s1)) ==
+             0;
+}
 
 inline bool AreListsEqual(const mg_list *list1, const mg_list *list2) {
   if (list1 == list2) {

--- a/mgclient_cpp/include/mgclient-value.hpp
+++ b/mgclient_cpp/include/mgclient-value.hpp
@@ -48,7 +48,8 @@ inline bool AreStringsEqual(const mg_string *s1, const mg_string *s2) {
   if (s1 == s2) return true;
   if (!s1 || !s2) return false;
   return mg_string_size(s1) == mg_string_size(s2) &&
-         memcmp(mg_string_data(s1), mg_string_data(s2), mg_string_size(s1)) == 0;
+         memcmp(mg_string_data(s1), mg_string_data(s2), mg_string_size(s1)) ==
+             0;
 }
 
 }  // namespace detail
@@ -1854,8 +1855,9 @@ inline bool AreDateTimeZoneIdsEqual(
              mg_date_time_zone_id_seconds(date_time_zone_id2) &&
          mg_date_time_zone_id_nanoseconds(date_time_zone_id1) ==
              mg_date_time_zone_id_nanoseconds(date_time_zone_id2) &&
-         detail::AreStringsEqual(mg_date_time_zone_id_timezone_name(date_time_zone_id1),
-                                 mg_date_time_zone_id_timezone_name(date_time_zone_id2));
+         detail::AreStringsEqual(
+             mg_date_time_zone_id_timezone_name(date_time_zone_id1),
+             mg_date_time_zone_id_timezone_name(date_time_zone_id2));
 }
 
 inline bool AreLocalDateTimesEqual(const mg_local_date_time *local_date_time1,

--- a/mgclient_cpp/include/mgclient-value.hpp
+++ b/mgclient_cpp/include/mgclient-value.hpp
@@ -43,6 +43,14 @@ TDest MemcpyCast(TSrc src) {
   std::memcpy(&dest, &src, sizeof(src));
   return dest;
 }
+
+inline bool AreStringsEqual(const mg_string *s1, const mg_string *s2) {
+  if (s1 == s2) return true;
+  if (!s1 || !s2) return false;
+  return mg_string_size(s1) == mg_string_size(s2) &&
+         memcmp(mg_string_data(s1), mg_string_data(s2), mg_string_size(s1)) == 0;
+}
+
 }  // namespace detail
 
 // Forward declarations:
@@ -1041,7 +1049,10 @@ class DateTimeZoneId final {
   /// Returns nanoseconds since midnight.
   int64_t nanoseconds() const { return mg_date_time_zone_id_nanoseconds(ptr_); }
   /// Returns time zone represented by the identifier.
-  int64_t tzId() const { return mg_date_time_zone_id_tz_id(ptr_); }
+  std::string_view timezoneName() const {
+    const mg_string *name = mg_date_time_zone_id_timezone_name(ptr_);
+    return std::string_view{mg_string_data(name), mg_string_size(name)};
+  }
 
   ConstDateTimeZoneId AsConstDateTimeZoneId() const;
 
@@ -1072,7 +1083,10 @@ class ConstDateTimeZoneId final {
     return mg_date_time_zone_id_nanoseconds(const_ptr_);
   }
   /// Returns time zone represented by the identifier.
-  int64_t tzId() const { return mg_date_time_zone_id_tz_id(const_ptr_); }
+  std::string_view timezoneName() const {
+    const mg_string *name = mg_date_time_zone_id_timezone_name(const_ptr_);
+    return std::string_view{mg_string_data(name), mg_string_size(name)};
+  }
 
   bool operator==(const ConstDateTimeZoneId &other) const;
   bool operator==(const DateTimeZoneId &other) const;
@@ -1840,8 +1854,8 @@ inline bool AreDateTimeZoneIdsEqual(
              mg_date_time_zone_id_seconds(date_time_zone_id2) &&
          mg_date_time_zone_id_nanoseconds(date_time_zone_id1) ==
              mg_date_time_zone_id_nanoseconds(date_time_zone_id2) &&
-         mg_date_time_zone_id_tz_id(date_time_zone_id1) ==
-             mg_date_time_zone_id_tz_id(date_time_zone_id2);
+         detail::AreStringsEqual(mg_date_time_zone_id_timezone_name(date_time_zone_id1),
+                                 mg_date_time_zone_id_timezone_name(date_time_zone_id2));
 }
 
 inline bool AreLocalDateTimesEqual(const mg_local_date_time *local_date_time1,

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -255,10 +255,7 @@ inline std::optional<std::vector<Value>> Client::FetchOne() {
   return values;
 }
 
-inline void Client::DiscardAll() {
-  while (FetchOne())
-    ;
-}
+inline void Client::DiscardAll() { while (FetchOne()); }
 
 inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {
   std::vector<std::vector<Value>> data;

--- a/mgclient_cpp/include/mgclient.hpp
+++ b/mgclient_cpp/include/mgclient.hpp
@@ -255,7 +255,10 @@ inline std::optional<std::vector<Value>> Client::FetchOne() {
   return values;
 }
 
-inline void Client::DiscardAll() { while (FetchOne()); }
+inline void Client::DiscardAll() {
+  while (FetchOne())
+    ;
+}
 
 inline std::optional<std::vector<std::vector<Value>>> Client::FetchAll() {
   std::vector<std::vector<Value>> data;

--- a/src/mgsession-decoder.c
+++ b/src/mgsession-decoder.c
@@ -714,7 +714,8 @@ int mg_session_read_date_time_zone_id(
     goto cleanup;
   }
 
-  status = mg_session_read_string(session, &date_time_zone_id_tmp->timezone_name);
+  status =
+      mg_session_read_string(session, &date_time_zone_id_tmp->timezone_name);
 
   *date_time_zone_id = date_time_zone_id_tmp;
   return 0;

--- a/src/mgsession-decoder.c
+++ b/src/mgsession-decoder.c
@@ -714,7 +714,7 @@ int mg_session_read_date_time_zone_id(
     goto cleanup;
   }
 
-  status = mg_session_read_integer(session, &date_time_zone_id_tmp->tz_id);
+  status = mg_session_read_string(session, &date_time_zone_id_tmp->timezone_name);
 
   *date_time_zone_id = date_time_zone_id_tmp;
   return 0;

--- a/src/mgsession-decoder.c
+++ b/src/mgsession-decoder.c
@@ -716,6 +716,9 @@ int mg_session_read_date_time_zone_id(
 
   status =
       mg_session_read_string(session, &date_time_zone_id_tmp->timezone_name);
+  if (status != 0) {
+    goto cleanup;
+  }
 
   *date_time_zone_id = date_time_zone_id_tmp;
   return 0;

--- a/src/mgsession-encoder.c
+++ b/src/mgsession-encoder.c
@@ -163,7 +163,8 @@ int mg_session_write_date_time(mg_session *session, const mg_date_time *dt) {
   MG_RETURN_IF_FAILED(mg_session_write_uint8(session, MG_SIGNATURE_DATE_TIME));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dt->seconds));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dt->nanoseconds));
-  MG_RETURN_IF_FAILED(mg_session_write_integer(session, dt->tz_offset_minutes * 60));
+  MG_RETURN_IF_FAILED(
+      mg_session_write_integer(session, dt->tz_offset_minutes * 60));
   return 0;
 }
 

--- a/src/mgsession-encoder.c
+++ b/src/mgsession-encoder.c
@@ -168,13 +168,16 @@ int mg_session_write_date_time(mg_session *session, const mg_date_time *dt) {
   return 0;
 }
 
-int mg_session_write_date_time_zone_id(mg_session *session, const mg_date_time_zone_id *dtz) {
+int mg_session_write_date_time_zone_id(mg_session *session,
+                                       const mg_date_time_zone_id *dtz) {
   MG_RETURN_IF_FAILED(
       mg_session_write_uint8(session, (uint8_t)(MG_MARKER_TINY_STRUCT3)));
-  MG_RETURN_IF_FAILED(mg_session_write_uint8(session, MG_SIGNATURE_DATE_TIME_ZONE_ID));
+  MG_RETURN_IF_FAILED(
+      mg_session_write_uint8(session, MG_SIGNATURE_DATE_TIME_ZONE_ID));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->seconds));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->nanoseconds));
-  MG_RETURN_IF_FAILED(mg_session_write_string(session, dtz->timezone_name->data));
+  MG_RETURN_IF_FAILED(
+      mg_session_write_string(session, dtz->timezone_name->data));
   return 0;
 }
 
@@ -251,7 +254,8 @@ int mg_session_write_value(mg_session *session, const mg_value *value) {
     case MG_VALUE_TYPE_DATE_TIME:
       return mg_session_write_date_time(session, value->date_time_v);
     case MG_VALUE_TYPE_DATE_TIME_ZONE_ID:
-      return mg_session_write_date_time_zone_id(session, value->date_time_zone_id_v);
+      return mg_session_write_date_time_zone_id(session,
+                                                value->date_time_zone_id_v);
     case MG_VALUE_TYPE_LOCAL_DATE_TIME:
       return mg_session_write_local_date_time(session,
                                               value->local_date_time_v);

--- a/src/mgsession-encoder.c
+++ b/src/mgsession-encoder.c
@@ -176,8 +176,8 @@ int mg_session_write_date_time_zone_id(mg_session *session,
       mg_session_write_uint8(session, MG_SIGNATURE_DATE_TIME_ZONE_ID));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->seconds));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->nanoseconds));
-  MG_RETURN_IF_FAILED(mg_session_write_string2(session, dtz->timezone_name->size,
-                                               dtz->timezone_name->data));
+  MG_RETURN_IF_FAILED(mg_session_write_string2(
+      session, dtz->timezone_name->size, dtz->timezone_name->data));
   return 0;
 }
 

--- a/src/mgsession-encoder.c
+++ b/src/mgsession-encoder.c
@@ -168,6 +168,16 @@ int mg_session_write_date_time(mg_session *session, const mg_date_time *dt) {
   return 0;
 }
 
+int mg_session_write_date_time_zone_id(mg_session *session, const mg_date_time_zone_id *dtz) {
+  MG_RETURN_IF_FAILED(
+      mg_session_write_uint8(session, (uint8_t)(MG_MARKER_TINY_STRUCT3)));
+  MG_RETURN_IF_FAILED(mg_session_write_uint8(session, MG_SIGNATURE_DATE_TIME_ZONE_ID));
+  MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->seconds));
+  MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->nanoseconds));
+  MG_RETURN_IF_FAILED(mg_session_write_string(session, dtz->timezone_name->data));
+  return 0;
+}
+
 int mg_session_write_duration(mg_session *session, const mg_duration *dur) {
   MG_RETURN_IF_FAILED(
       mg_session_write_uint8(session, (uint8_t)(MG_MARKER_TINY_STRUCT4)));
@@ -241,9 +251,7 @@ int mg_session_write_value(mg_session *session, const mg_value *value) {
     case MG_VALUE_TYPE_DATE_TIME:
       return mg_session_write_date_time(session, value->date_time_v);
     case MG_VALUE_TYPE_DATE_TIME_ZONE_ID:
-      mg_session_set_error(session,
-                           "tried to send value of type 'date_time_zone_id'");
-      return MG_ERROR_INVALID_VALUE;
+      return mg_session_write_date_time_zone_id(session, value->date_time_zone_id_v);
     case MG_VALUE_TYPE_LOCAL_DATE_TIME:
       return mg_session_write_local_date_time(session,
                                               value->local_date_time_v);

--- a/src/mgsession-encoder.c
+++ b/src/mgsession-encoder.c
@@ -176,8 +176,8 @@ int mg_session_write_date_time_zone_id(mg_session *session,
       mg_session_write_uint8(session, MG_SIGNATURE_DATE_TIME_ZONE_ID));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->seconds));
   MG_RETURN_IF_FAILED(mg_session_write_integer(session, dtz->nanoseconds));
-  MG_RETURN_IF_FAILED(
-      mg_session_write_string(session, dtz->timezone_name->data));
+  MG_RETURN_IF_FAILED(mg_session_write_string2(session, dtz->timezone_name->size,
+                                               dtz->timezone_name->data));
   return 0;
 }
 

--- a/src/mgsession-encoder.c
+++ b/src/mgsession-encoder.c
@@ -157,6 +157,16 @@ int mg_session_write_local_date_time(mg_session *session,
   return 0;
 }
 
+int mg_session_write_date_time(mg_session *session, const mg_date_time *dt) {
+  MG_RETURN_IF_FAILED(
+      mg_session_write_uint8(session, (uint8_t)(MG_MARKER_TINY_STRUCT3)));
+  MG_RETURN_IF_FAILED(mg_session_write_uint8(session, MG_SIGNATURE_DATE_TIME));
+  MG_RETURN_IF_FAILED(mg_session_write_integer(session, dt->seconds));
+  MG_RETURN_IF_FAILED(mg_session_write_integer(session, dt->nanoseconds));
+  MG_RETURN_IF_FAILED(mg_session_write_integer(session, dt->tz_offset_minutes * 60));
+  return 0;
+}
+
 int mg_session_write_duration(mg_session *session, const mg_duration *dur) {
   MG_RETURN_IF_FAILED(
       mg_session_write_uint8(session, (uint8_t)(MG_MARKER_TINY_STRUCT4)));
@@ -228,8 +238,7 @@ int mg_session_write_value(mg_session *session, const mg_value *value) {
     case MG_VALUE_TYPE_LOCAL_TIME:
       return mg_session_write_local_time(session, value->local_time_v);
     case MG_VALUE_TYPE_DATE_TIME:
-      mg_session_set_error(session, "tried to send value of type 'date_time'");
-      return MG_ERROR_INVALID_VALUE;
+      return mg_session_write_date_time(session, value->date_time_v);
     case MG_VALUE_TYPE_DATE_TIME_ZONE_ID:
       mg_session_set_error(session,
                            "tried to send value of type 'date_time_zone_id'");

--- a/src/mgvalue.c
+++ b/src/mgvalue.c
@@ -1657,7 +1657,7 @@ mg_local_time *mg_local_time_make(int64_t nanoseconds) {
   return lt;
 }
 
-mg_date_time *mg_zoned_date_time_make(int64_t seconds, int64_t nanoseconds,
+mg_date_time *mg_date_time_make(int64_t seconds, int64_t nanoseconds,
                                       int32_t tz_offset_minutes) {
   mg_date_time *dt = mg_date_time_alloc(&mg_system_allocator);
   if (!dt) {

--- a/src/mgvalue.c
+++ b/src/mgvalue.c
@@ -1657,6 +1657,18 @@ mg_local_time *mg_local_time_make(int64_t nanoseconds) {
   return lt;
 }
 
+mg_date_time *mg_zoned_date_time_make(int64_t seconds, int64_t nanoseconds,
+                                      int32_t tz_offset_minutes) {
+  mg_date_time *dt = mg_date_time_alloc(&mg_system_allocator);
+  if (!dt) {
+    return NULL;
+  }
+  dt->seconds = seconds;
+  dt->nanoseconds = nanoseconds;
+  dt->tz_offset_minutes = tz_offset_minutes;
+  return dt;
+}
+
 mg_local_date_time *mg_local_date_time_make(int64_t seconds,
                                             int64_t nanoseconds) {
   mg_local_date_time *ldt = mg_local_date_time_alloc(&mg_system_allocator);

--- a/src/mgvalue.c
+++ b/src/mgvalue.c
@@ -1279,9 +1279,9 @@ int64_t mg_date_time_zone_id_nanoseconds(
   return date_time_zone_id->nanoseconds;
 }
 
-int64_t mg_date_time_zone_id_tz_id(
+const mg_string *mg_date_time_zone_id_timezone_name(
     const mg_date_time_zone_id *date_time_zone_id) {
-  return date_time_zone_id->tz_id;
+  return date_time_zone_id->timezone_name;
 }
 
 int64_t mg_local_date_time_seconds(const mg_local_date_time *local_date_time) {
@@ -1826,7 +1826,7 @@ int mg_local_date_time_equal(const mg_local_date_time *lhs,
 int mg_date_time_zone_id_equal(const mg_date_time_zone_id *lhs,
                                const mg_date_time_zone_id *rhs) {
   return lhs->seconds == rhs->seconds && lhs->nanoseconds == rhs->nanoseconds &&
-         lhs->tz_id == rhs->tz_id;
+         mg_string_equal(lhs->timezone_name, rhs->timezone_name) == 0;
 }
 
 int mg_duration_equal(const mg_duration *lhs, const mg_duration *rhs) {

--- a/src/mgvalue.c
+++ b/src/mgvalue.c
@@ -1826,7 +1826,7 @@ int mg_local_date_time_equal(const mg_local_date_time *lhs,
 int mg_date_time_zone_id_equal(const mg_date_time_zone_id *lhs,
                                const mg_date_time_zone_id *rhs) {
   return lhs->seconds == rhs->seconds && lhs->nanoseconds == rhs->nanoseconds &&
-         mg_string_equal(lhs->timezone_name, rhs->timezone_name) == 0;
+         mg_string_equal(lhs->timezone_name, rhs->timezone_name);
 }
 
 int mg_duration_equal(const mg_duration *lhs, const mg_duration *rhs) {

--- a/src/mgvalue.c
+++ b/src/mgvalue.c
@@ -134,6 +134,9 @@ mg_date_time_zone_id *mg_date_time_zone_id_alloc(mg_allocator *allocator) {
     return NULL;
   }
   mg_date_time_zone_id *date_time_zone_id = (mg_date_time_zone_id *)block;
+  date_time_zone_id->seconds = 0;
+  date_time_zone_id->nanoseconds = 0;
+  date_time_zone_id->timezone_name = NULL;
   return date_time_zone_id;
 }
 
@@ -1442,7 +1445,13 @@ mg_date_time_zone_id *mg_date_time_zone_id_copy_ca(
   if (!date_time_zone_id) {
     return NULL;
   }
-  memcpy(date_time_zone_id, src, sizeof(mg_date_time_zone_id));
+  date_time_zone_id->seconds = src->seconds;
+  date_time_zone_id->nanoseconds = src->nanoseconds;
+  date_time_zone_id->timezone_name = mg_string_copy_ca(src->timezone_name, allocator);
+  if (!date_time_zone_id->timezone_name) {
+    mg_date_time_zone_id_destroy_ca(date_time_zone_id, allocator);
+    return NULL;
+  }
   return date_time_zone_id;
 }
 
@@ -1456,6 +1465,7 @@ void mg_date_time_zone_id_destroy_ca(mg_date_time_zone_id *date_time_zone_id,
   if (!date_time_zone_id) {
     return;
   }
+  mg_string_destroy_ca(date_time_zone_id->timezone_name, allocator);
   mg_allocator_free(allocator, date_time_zone_id);
 }
 

--- a/src/mgvalue.c
+++ b/src/mgvalue.c
@@ -1658,7 +1658,7 @@ mg_local_time *mg_local_time_make(int64_t nanoseconds) {
 }
 
 mg_date_time *mg_date_time_make(int64_t seconds, int64_t nanoseconds,
-                                      int32_t tz_offset_minutes) {
+                                int32_t tz_offset_minutes) {
   mg_date_time *dt = mg_date_time_alloc(&mg_system_allocator);
   if (!dt) {
     return NULL;
@@ -1667,6 +1667,27 @@ mg_date_time *mg_date_time_make(int64_t seconds, int64_t nanoseconds,
   dt->nanoseconds = nanoseconds;
   dt->tz_offset_minutes = tz_offset_minutes;
   return dt;
+}
+
+mg_date_time_zone_id *mg_date_time_zone_id_make(int64_t seconds,
+                                                int64_t nanoseconds,
+                                                const char *timezone_name) {
+  mg_date_time_zone_id *dt_zone_id =
+      mg_date_time_zone_id_alloc(&mg_system_allocator);
+  if (!dt_zone_id) {
+    return NULL;
+  }
+
+  mg_string *tz_name = mg_string_make(timezone_name);
+  if (!tz_name) {
+    mg_date_time_zone_id_destroy_ca(dt_zone_id, &mg_system_allocator);
+    return NULL;
+  }
+
+  dt_zone_id->seconds = seconds;
+  dt_zone_id->nanoseconds = nanoseconds;
+  dt_zone_id->timezone_name = tz_name;
+  return dt_zone_id;
 }
 
 mg_local_date_time *mg_local_date_time_make(int64_t seconds,

--- a/src/mgvalue.c
+++ b/src/mgvalue.c
@@ -1447,7 +1447,8 @@ mg_date_time_zone_id *mg_date_time_zone_id_copy_ca(
   }
   date_time_zone_id->seconds = src->seconds;
   date_time_zone_id->nanoseconds = src->nanoseconds;
-  date_time_zone_id->timezone_name = mg_string_copy_ca(src->timezone_name, allocator);
+  date_time_zone_id->timezone_name =
+      mg_string_copy_ca(src->timezone_name, allocator);
   if (!date_time_zone_id->timezone_name) {
     mg_date_time_zone_id_destroy_ca(date_time_zone_id, allocator);
     return NULL;

--- a/src/mgvalue.h
+++ b/src/mgvalue.h
@@ -94,7 +94,7 @@ typedef struct mg_date_time {
 typedef struct mg_date_time_zone_id {
   int64_t seconds;
   int64_t nanoseconds;
-  int64_t tz_id;
+  mg_string *timezone_name;
 } mg_date_time_zone_id;
 
 typedef struct mg_local_date_time {

--- a/tests/bolt-testdata.hpp
+++ b/tests/bolt-testdata.hpp
@@ -445,13 +445,14 @@ std::vector<ValueTestParam> DateTimeZoneIdTestCases() {
 
     date_time_zone_id->seconds = 1;
     date_time_zone_id->nanoseconds = 1;
-    date_time_zone_id->tz_id = 1;
+    date_time_zone_id->timezone_name = mg_string_make("Europe/Zagreb");
 
     std::string encoded_date_time_zone_id;
     encoded_date_time_zone_id += "\xB3\x66"s;
     encoded_date_time_zone_id += "\x01"s;
     encoded_date_time_zone_id += "\x01"s;
-    encoded_date_time_zone_id += "\x01"s;
+    encoded_date_time_zone_id += "\x8D"s;
+    encoded_date_time_zone_id += "Europe/Zagreb"s;
 
     inputs.push_back({mg_value_make_date_time_zone_id(date_time_zone_id),
                       encoded_date_time_zone_id});

--- a/tests/encoder.cpp
+++ b/tests/encoder.cpp
@@ -298,6 +298,9 @@ INSTANTIATE_TEST_CASE_P(LocalTime, ValueTest,
 INSTANTIATE_TEST_CASE_P(LocalDateTime, ValueTest,
                         ::testing::ValuesIn(LocalDateTimeTestCases()), );
 
+INSTANTIATE_TEST_CASE_P(DateTime, ValueTest,
+                        ::testing::ValuesIn(DateTimeTestCases()), );
+
 INSTANTIATE_TEST_CASE_P(Duration, ValueTest,
                         ::testing::ValuesIn((DurationTestCases())), );
 

--- a/tests/value.cpp
+++ b/tests/value.cpp
@@ -527,7 +527,8 @@ TEST(Value, DateTimeZoneId) {
               static_cast<int64_t>(1));
     EXPECT_EQ(mg_date_time_zone_id_nanoseconds(date_time_zone_id),
               static_cast<int64_t>(1));
-    const mg_string *tz_name = mg_date_time_zone_id_timezone_name(date_time_zone_id);
+    const mg_string *tz_name =
+        mg_date_time_zone_id_timezone_name(date_time_zone_id);
     EXPECT_STREQ(mg_string_data(tz_name), "Europe/Zagreb");
     mg_date_time_zone_id *date_time_zone_id2 =
         mg_date_time_zone_id_copy(date_time_zone_id);
@@ -536,7 +537,8 @@ TEST(Value, DateTimeZoneId) {
               static_cast<int64_t>(1));
     EXPECT_EQ(mg_date_time_zone_id_nanoseconds(date_time_zone_id2),
               static_cast<int64_t>(1));
-    const mg_string *tz_name2 = mg_date_time_zone_id_timezone_name(date_time_zone_id2);
+    const mg_string *tz_name2 =
+        mg_date_time_zone_id_timezone_name(date_time_zone_id2);
     EXPECT_STREQ(mg_string_data(tz_name2), "Europe/Zagreb");
     mg_date_time_zone_id_destroy(date_time_zone_id2);
   }

--- a/tests/value.cpp
+++ b/tests/value.cpp
@@ -522,13 +522,13 @@ TEST(Value, DateTimeZoneId) {
         mg_date_time_zone_id_alloc(&mg_system_allocator);
     date_time_zone_id->seconds = 1;
     date_time_zone_id->nanoseconds = 1;
-    date_time_zone_id->tz_id = 1;
+    date_time_zone_id->timezone_name = mg_string_make("Europe/Zagreb");
     EXPECT_EQ(mg_date_time_zone_id_seconds(date_time_zone_id),
               static_cast<int64_t>(1));
     EXPECT_EQ(mg_date_time_zone_id_nanoseconds(date_time_zone_id),
               static_cast<int64_t>(1));
-    EXPECT_EQ(mg_date_time_zone_id_tz_id(date_time_zone_id),
-              static_cast<int64_t>(1));
+    const mg_string *tz_name = mg_date_time_zone_id_timezone_name(date_time_zone_id);
+    EXPECT_STREQ(mg_string_data(tz_name), "Europe/Zagreb");
     mg_date_time_zone_id *date_time_zone_id2 =
         mg_date_time_zone_id_copy(date_time_zone_id);
     mg_date_time_zone_id_destroy(date_time_zone_id);
@@ -536,8 +536,8 @@ TEST(Value, DateTimeZoneId) {
               static_cast<int64_t>(1));
     EXPECT_EQ(mg_date_time_zone_id_nanoseconds(date_time_zone_id2),
               static_cast<int64_t>(1));
-    EXPECT_EQ(mg_date_time_zone_id_tz_id(date_time_zone_id2),
-              static_cast<int64_t>(1));
+    const mg_string *tz_name2 = mg_date_time_zone_id_timezone_name(date_time_zone_id2);
+    EXPECT_STREQ(mg_string_data(tz_name2), "Europe/Zagreb");
     mg_date_time_zone_id_destroy(date_time_zone_id2);
   }
 }

--- a/tests/value.cpp
+++ b/tests/value.cpp
@@ -529,7 +529,7 @@ TEST(Value, DateTimeZoneId) {
               static_cast<int64_t>(1));
     const mg_string *tz_name =
         mg_date_time_zone_id_timezone_name(date_time_zone_id);
-    EXPECT_STREQ(mg_string_data(tz_name), "Europe/Zagreb");
+    EXPECT_TRUE(Equal(tz_name, "Europe/Zagreb"s));
     mg_date_time_zone_id *date_time_zone_id2 =
         mg_date_time_zone_id_copy(date_time_zone_id);
     mg_date_time_zone_id_destroy(date_time_zone_id);
@@ -539,7 +539,7 @@ TEST(Value, DateTimeZoneId) {
               static_cast<int64_t>(1));
     const mg_string *tz_name2 =
         mg_date_time_zone_id_timezone_name(date_time_zone_id2);
-    EXPECT_STREQ(mg_string_data(tz_name2), "Europe/Zagreb");
+    EXPECT_TRUE(Equal(tz_name2, "Europe/Zagreb"s));
     mg_date_time_zone_id_destroy(date_time_zone_id2);
   }
 }


### PR DESCRIPTION
Encode and decode `ZonedDateTime` types, both those with numeric based offsets (such as 60 minutes), and named timezones (such as `[America/New_York]`.)

Technically, a `struct` has been changed that would be breaking, but as this couldn't be used in transport we know that no clients were actually using it.

This also updates the version to 1.5.0.