### PR TITLE
CI Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,8 @@ jobs:
       - name: Download, install and run Memgraph under WSL
         shell: wsl-bash {0} # root shell
         run: |
+          sudo apt update
+          sudo apt install -y libatomic1
           mkdir ~/memgraph
           curl -L https://download.memgraph.com/memgraph/v${{ env.MGVERSION }}/ubuntu-24.04/memgraph_${{ env.MGVERSION }}-1_amd64.deb --output ~/memgraph/memgraph.deb
           dpkg -i ~/memgraph/memgraph.deb

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ FetchContent_Declare(googletest
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 FetchContent_MakeAvailable(googletest)
 
 set(TESTS_ROOT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
- install missing `libatomic1` prior to install memgraph in the Windows builds
- override minimum `cmake` version 